### PR TITLE
Fix parsing failure for values having = symbol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>luchiniatwork</groupId>
   <artifactId>ambiente</artifactId>
-  <version>0.1.4</version>
+  <version>0.1.5-SNAPSHOT</version>
   <name>ambiente</name>
   <dependencies>
     <dependency>

--- a/src/ambiente/core.clj
+++ b/src/ambiente/core.clj
@@ -25,11 +25,9 @@
   (->> rawstring
        s/split-lines
        (map s/trim)
-       (remove #(-> % empty?
-                    (s/starts-with? "#")))
-       (map #(s/split % #"="))
-       (map #(vec (->> % (map s/trim)
-                       (map unquote-string))))))
+       (remove #(-> % empty? (s/starts-with? "#")))
+       (map #(s/split % #"=" 2))
+       (map #(vec (->> % (map s/trim) (map unquote-string))))))
 
 (defn ^:private keywordize [s]
   (-> (s/lower-case s)

--- a/test/ambiente/core_test.clj
+++ b/test/ambiente/core_test.clj
@@ -92,7 +92,11 @@
   (testing ".env file ignore comments"
     (spit ".env" "#FOO=bar\nFOO=baz")
     (let [env (refresh-env)]
-      (is (= (:foo env) "baz")))))
+      (is (= (:foo env) "baz"))))
+  (testing ".env file with = in values"
+    (spit ".env" "FOO=BAR=BAZ")
+    (let [env (refresh-env)]
+      (is (= (:foo env) "BAR=BAZ")))))
 
 (deftest test-priority-order
   (testing ".env trumps .env.edn"


### PR DESCRIPTION
Hi Tiago,

I found this little bug that cuts off a values right before an = symbol. This PR fixes it.